### PR TITLE
feat: fix lamp_spot_light glowing when off

### DIFF
--- a/content/SmallFixes/chunk1/lamp_spot_light_c.entity.patch.json
+++ b/content/SmallFixes/chunk1/lamp_spot_light_c.entity.patch.json
@@ -1,0 +1,19 @@
+{
+	"tempHash": "00A1045D1675A0D2",
+	"tbluHash": "00E937BCE87DD459",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"bbd5d2b30620920a",
+				{
+					"AddEventConnection": [
+						"GlowPower",
+						"ConstantVector1D_07_Value",
+						"4ff4027b3f90e35c"
+					]
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Added a missing event to control the lamp glowing when on/off

This is how it looks in vanillla:
![vanilla](https://github.com/user-attachments/assets/39c07987-0362-4f56-84a0-18da61e541da)

This is how it looks with the fix:
![fixed](https://github.com/user-attachments/assets/d73be312-93cf-430f-95dc-f0f77d06df6c)