### PR TITLE
feat: make floating pins from pinboard invisible

### DIFF
--- a/content/SmallFixes/chunk19/BoatshopPinboard/location.entity.patch.json
+++ b/content/SmallFixes/chunk19/BoatshopPinboard/location.entity.patch.json
@@ -1,0 +1,62 @@
+{
+	"tempHash": "0056406088754691",
+	"tbluHash": "00CF14C55C3BCCA8",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"3dfc52b9eb01c0f2",
+				{
+					"AddProperty": [
+						"m_bVisible",
+						{ "type": "bool", "value": false }
+					]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"287cef278e5b7e81",
+				{
+					"AddProperty": [
+						"m_bVisible",
+						{ "type": "bool", "value": false }
+					]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"06962c98bfe2bf35",
+				{
+					"AddProperty": [
+						"m_bVisible",
+						{ "type": "bool", "value": false }
+					]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"c8deb4328aeddbbb",
+				{
+					"AddProperty": [
+						"m_bVisible",
+						{ "type": "bool", "value": false }
+					]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"1d590a073fca618a",
+				{
+					"AddProperty": [
+						"m_bVisible",
+						{ "type": "bool", "value": false }
+					]
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Changes some unused pins on the pinboard to be invisible so that they don't float in the air (there's actually just one that's visible the others are in the walls)

![HITMAN3_EdyOrJyhcd](https://github.com/user-attachments/assets/5c2a3140-c2e7-429d-87e7-8f17dec4fd30)

![HITMAN3_nR5Ee6vHSs](https://github.com/user-attachments/assets/bc29fedb-8ef4-4290-b303-35cb1534a393)