### PR TITLE
feat: fix flares and smoke grenades not being audible

### DIFF
--- a/content/SmallFixes/chunk25/RiotSmokeGrenadesSoundFix/smoke_grenade_a.entity.patch.json
+++ b/content/SmallFixes/chunk25/RiotSmokeGrenadesSoundFix/smoke_grenade_a.entity.patch.json
@@ -1,0 +1,32 @@
+{
+	"tempHash": "002E2C34CB417286",
+	"tbluHash": "00EABFB2DA277D15",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"d4ad3e24de1db324",
+				{
+					"AddProperty": [
+						"m_bValue",
+						{ "type": "bool", "value": true }
+					]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"67774755d2addd7c",
+				{
+					"AddPropertyAliasConnection": [
+						"On",
+						{
+							"originalProperty": "m_bValue",
+							"originalEntity": "d4ad3e24de1db324"
+						}
+					]
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}

--- a/content/SmallFixes/chunk8/RiotFlaresSoundFix/flare_a.entity.patch.json
+++ b/content/SmallFixes/chunk8/RiotFlaresSoundFix/flare_a.entity.patch.json
@@ -1,0 +1,25 @@
+{
+	"tempHash": "003192FCF97D67DA",
+	"tbluHash": "00F4B647CC2C44FE",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"4e071b0b7d81b87b",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_mTransform",
+						"value": {
+							"rotation": {
+								"x": 0.0,
+								"y": 0.0,
+								"z": 0.0
+							},
+							"position": { "x": 0.0, "y": 0.0, "z": 0.25 }
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Moves the sound of the flares to origin to match the actual position of the item and adds missing valuebool connection to the smoke grenades