### PR TITLE
feat: swap dialogue to match actions

### DIFF
--- a/content/SmallFixes/chunk25/ActorSwapping/npc_mission_spider.entity.patch.json
+++ b/content/SmallFixes/chunk25/ActorSwapping/npc_mission_spider.entity.patch.json
@@ -1,0 +1,29 @@
+{
+	"tempHash": "004868F794D35933",
+	"tbluHash": "006E467BCDA40509",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"ddcdf55c643feeb5",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_targetEntity",
+						"value": "15b00947bdd250a7"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"38e3a33792f95495",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_targetEntity",
+						"value": "950a92814c3d81c0"
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Inverses the actors during the dialogue between the printing crew to reflect their actions in the game
(Thanks Sinful Monsoon on Discord for reporting it)