### PR TITLE
feat: fix RFID explosive triggering on crowds

### DIFF
--- a/content/SmallFixes/chunk0/RFIDCrowdFix/prophelper_ica_trigger_proximity.entity.patch.json
+++ b/content/SmallFixes/chunk0/RFIDCrowdFix/prophelper_ica_trigger_proximity.entity.patch.json
@@ -1,0 +1,43 @@
+{
+	"tempHash": "00E785AE3BC8DDB9",
+	"tbluHash": "00915C30DBC37052",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"d4e43d75e1e11009",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pCondition",
+						"value": "cafe637d7600b789"
+					}
+				}
+			]
+		},
+		{
+			"AddEntity": [
+				"cafe637d7600b789",
+				{
+					"parent": "d4e43d75e1e11009",
+					"name": "ActiveAndNotRFID",
+					"factory": "[assembly:/_pro/design/logic/valuebool.template?/valuebool_operation.entitytemplate].pc_entitytype",
+					"blueprint": "[assembly:/_pro/design/logic/valuebool.template?/valuebool_operation.entitytemplate].pc_entityblueprint",
+					"properties": {
+						"m_eEvaluation": {
+							"type": "ZValueBool_Operation_Signal.EEvaluationType",
+							"value": "ALL"
+						},
+						"m_aValues": {
+							"type": "TArray<SEntityTemplateReference>",
+							"value": [
+								"2b2a7fd79d02dfe0",
+								"a5aa6d39f3889650"
+							],
+							"postInit": true
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
In the base game, the RFID proximity explosive explodes from proximity to a crowd. This patch fixes it to only detonate with the coin present.