### PR TITLE
feat: fix rook positioning in The Final Test

### DIFF
--- a/content/SmallFixes/chunk0/GraduationRookPosition/fix_rook_ending_position.entity.patch.json
+++ b/content/SmallFixes/chunk0/GraduationRookPosition/fix_rook_ending_position.entity.patch.json
@@ -1,0 +1,29 @@
+{
+	"tempHash": "00FABAF9A85B05DC",
+	"tbluHash": "00D715AE4D6BCD71",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"c5ea4ca17d6316dd",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_mTransform",
+						"value": {
+							"rotation": {
+								"x": 90.00000250447806,
+								"y": 0.0,
+								"z": -90.00003977682577
+							},
+							"position": {
+								"x": 0.05984551087021828,
+								"y": 0.14108170568943024,
+								"z": 0.013
+							}
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}

--- a/content/SmallFixes/chunk0/GraduationRookPosition/fix_rook_starting_position.entity.patch.json
+++ b/content/SmallFixes/chunk0/GraduationRookPosition/fix_rook_starting_position.entity.patch.json
@@ -1,0 +1,74 @@
+{
+	"tempHash": "00FABAF9A85B05DC",
+	"tbluHash": "00D715AE4D6BCD71",
+	"patch": [
+		{
+			"AddEntity": [
+				"cafed7ea406f22d2",
+				{
+					"parent": "874518581c05250a",
+					"name": "HACK - Reset on gameplay and save load",
+					"factory": "[modules:/zentity.class].pc_entitytype",
+					"blueprint": "[modules:/zentity.class].pc_entityblueprint"
+				}
+			]
+		},
+		{
+			"AddEntity": [
+				"cafe4cf4ae19da3b",
+				{
+					"parent": "cafed7ea406f22d2",
+					"name": "Has a move been made?",
+					"factory": "[assembly:/_pro/design/logic/valuebool.template?/valuebool_poll.entitytemplate].pc_entitytype",
+					"blueprint": "[assembly:/_pro/design/logic/valuebool.template?/valuebool_poll.entitytemplate].pc_entityblueprint",
+					"properties": {
+						"m_rValueEntity": {
+							"type": "SEntityTemplateReference",
+							"value": "8b3f840cfdfd9481"
+						}
+					},
+					"events": {
+						"PollFalse": {
+							"DEBUG_Reset": ["874518581c05250a"]
+						}
+					}
+				}
+			]
+		},
+		{
+			"AddEntity": [
+				"cafe3a9be6ffd4ea",
+				{
+					"parent": "cafed7ea406f22d2",
+					"name": "On gameplay start",
+					"factory": "[modules:/zgameeventlistenerentity.class].pc_entitytype",
+					"blueprint": "[modules:/zgameeventlistenerentity.class].pc_entityblueprint",
+					"events": {
+						"EventOccurred": { "Poll": ["cafe4cf4ae19da3b"] }
+					}
+				}
+			]
+		},
+		{
+			"AddEntity": [
+				"cafe9d4473b44b40",
+				{
+					"parent": "cafed7ea406f22d2",
+					"name": "On save load",
+					"factory": "[modules:/zgameeventlistenerentity.class].pc_entitytype",
+					"blueprint": "[modules:/zgameeventlistenerentity.class].pc_entityblueprint",
+					"properties": {
+						"m_eEvent": {
+							"type": "EGameEventType",
+							"value": "GET_SavegameRestored"
+						}
+					},
+					"events": {
+						"EventOccurred": { "Poll": ["cafe4cf4ae19da3b"] }
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Fixes #318

Needs a little bit of testing, I've made sure it doesn't erroneously return to the ending position on start and save/load. I don't think there's another way it could reset back to there.