### PR TITLE
feat: swap shorts and fix colliders for Purple Streak/Splitter Boxer Suits

### DIFF
--- a/content/SmallFixes/chunk0/KickTheBoxerFixes/replace_kicktheboxer_purple_shorts.entity.patch.json
+++ b/content/SmallFixes/chunk0/KickTheBoxerFixes/replace_kicktheboxer_purple_shorts.entity.patch.json
@@ -1,0 +1,142 @@
+{
+	"tempHash": "00E70F1245D35AF6",
+	"tbluHash": "006BC1D9EA8AE7B3",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"7699f3603c049828",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.15
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"7ee9f8a91ef18466",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.11
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"6e5f632cb49c09fd",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.11
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"efccb2e7122a4218",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.12
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"0e58631af6b03a2f",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pMeshResource",
+						"value": {
+							"resource": "001A9DFE654F3BE5",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"1f753c1eeb952ada",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.15
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"5d78508dd30d105f",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.12
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": ["24ceb24873db4d30", { "SetName": "conor_mcgregor_shorts" }]
+		},
+		{
+			"SubEntityOperation": [
+				"24ceb24873db4d30",
+				{
+					"SetFactory": "[assembly:/_pro/characters/assets/individuals/magpie/conor_mcgregor/materials/conor_mcgregor_shorts.mi].pc_entitytype"
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"24ceb24873db4d30",
+				{
+					"SetBlueprint": "[assembly:/_pro/characters/assets/individuals/magpie/conor_mcgregor/materials/conor_mcgregor_shorts.mi].pc_entityblueprint"
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"a67e7c5409cf405b",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pMeshResource",
+						"value": {
+							"resource": "001A9DFE654F3BE5",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"f02fdb8f447aadec",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.15
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"c7cce8093e63e3b2",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.15
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}

--- a/content/SmallFixes/chunk0/KickTheBoxerFixes/replace_kicktheboxer_shorts.entity.patch.json
+++ b/content/SmallFixes/chunk0/KickTheBoxerFixes/replace_kicktheboxer_shorts.entity.patch.json
@@ -1,0 +1,142 @@
+{
+	"tempHash": "0095CFD72C451029",
+	"tbluHash": "00E28EB5F7148186",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"061ec2c7fbf48d02",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.12
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"1dd275c7e83f4ea9",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.11
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"48472e5d803c3a05",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.12
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": ["ae37721a2b71aa18", { "SetName": "conor_mcgregor_shorts" }]
+		},
+		{
+			"SubEntityOperation": [
+				"ae37721a2b71aa18",
+				{
+					"SetFactory": "[assembly:/_pro/characters/assets/individuals/magpie/conor_mcgregor/materials/conor_mcgregor_shorts.mi].pc_entitytype"
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"ae37721a2b71aa18",
+				{
+					"SetBlueprint": "[assembly:/_pro/characters/assets/individuals/magpie/conor_mcgregor/materials/conor_mcgregor_shorts.mi].pc_entityblueprint"
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"7fa0487ae1fd3794",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.15
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"55e83f0254e1cc0c",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.11
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"9dd006357c3513bf",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.15
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"dcb114108135c418",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.15
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"7646d0a4bbb1c7c8",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fRadius",
+						"value": 0.15
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"0bc1830b24b12683",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pMeshResource",
+						"value": {
+							"resource": "001A9DFE654F3BE5",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"65af0ce7789308a5",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pMeshResource",
+						"value": {
+							"resource": "001A9DFE654F3BE5",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Fixes #255 & Supersedes #259

There is still some clipping in certain situations, but it's at the front when running up stairs (and ever so slightly when running or crouching in general, but I suspect this occurs on the vanilla suits) but the most egregious clipping at the back has been fixed.

On the black robe this is not very noticeable, less so on the Twitch version. It's a lot better than before though.