### PR TITLE
feat: fix Safehouse exit audio for Berlin + Dubai choppers

### DIFF
--- a/content/SmallFixes/chunk29/BerlinAndDubaiChopperSounds/vehicle_exit_sound_fixes.entity.patch.json
+++ b/content/SmallFixes/chunk29/BerlinAndDubaiChopperSounds/vehicle_exit_sound_fixes.entity.patch.json
@@ -1,0 +1,87 @@
+{
+	"tempHash": "00A9B93A825F5BDC",
+	"tbluHash": "005BA5CA6AC00627",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"28a4269943849d66",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pMainEvent",
+						"value": {
+							"resource": "[assembly:/sound/wwise/exportedwwisedata/events/sfx_cutscenes/sfx_cutscenes_evergreen/play_cin_evergreen_safehouse_exit_motorcycle.wwiseevent].pc_wwisebank",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"1eb8ada1534036cb",
+				{
+					"AddEventConnection": [
+						"OnSkip",
+						"SetTrue",
+						"3b58915b9d6bee0f"
+					]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"9cb4d1085c8689ff",
+				{ "SetName": "SeqDir_Exit_helicopter_gecko_a" }
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"dca6ebd9f45d7aae",
+				{
+					"RemoveEventConnection": [
+						"OnPlay",
+						"StartRotorFullSpeed",
+						"fdde26e8b2d8e4b4"
+					]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"dca6ebd9f45d7aae",
+				{
+					"AddEventConnection": [
+						"OnPlay",
+						"StartRotorFullSpeed",
+						"b18036ef09e60bbf"
+					]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"34cd832f1078fa7f",
+				{ "SetName": "VB_SOUND_CutscenePlaying_Helicopter_Gecko" }
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"c0a327bfefe70a35",
+				{
+					"PatchArrayPropertyValue": [
+						"m_aValues",
+						[
+							{
+								"AddItemAfter": [
+									"3b09a9d51e8350b6",
+									"34cd832f1078fa7f"
+								]
+							}
+						]
+					]
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
- fixes #137
- black & gold helicopter from Dubai now has sound when leaving the safehouse
- motorcycle from Berlin now uses the same sound as the Dartmoor motorcycle when leaving the safehouse