### PR TITLE
feat: fix numerous typos and improve translations

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -129,6 +129,11 @@
 				"4247778829": "Estranged daughter of Robert Knox, Sierra Knox wasn't dealt the best of cards from her early childhood. Her mother died due to complications from childbirth, a fact that Sierra to this day still believes her father holds her secretly responsible for.<br><br>Growing up with a father who always worked, Sierra developed a somewhat reckless personality, always trying to out-do everyone else – including her old man. At age of 17, she was deeply involved with competitive short distance running and, worried that she might lose to her high school competitor, paid a man to ensure the competitor didn't run that afternoon. The competitor was chained to a wheelchair for the rest of her life while Sierra won the race easily. The tactic is one she would use again and again to get the upper hand in both athletics and life in general.<br><br>Sierra Knox graduated from Harvard business school and, without telling her father, secured a job with Kronstadt Industries, diligently working her way to the top of the financial department, finally interviewing for the position of CFO with her somewhat surprised father.<br><br>Sierra Knox has been instrumental in developing the money-earning side of the family business, and she has secured many deals with foreign nationals, including a very controversial decision to field test robot matériel in several rogue nations. While the loss of civilian life was never formally assigned as collateral damage following those tests, leaked internal reports suggest as much.<br><br>Sierra suffers from a serious inferiority complex in relation to her father. Always trying to prove herself to him but often coming up short, she is uncertain about whether he truly cares for her or not. Her insecurity causes her to act out, often irrationally or violently, and she is known for her lifestyle of working hard and partying even harder.<br><br>Sierra Knox is currently highly invested in the Kronstadt racing team and is the company’s lead driver in the Innovation Race. She’s won the race multiple times and is expected to bring home the trophy again."
 			}
 		},
+		"000C2FF325E2CF7D": {
+			"spanish": {
+				"3566935146": "Pesadilla en Bahía de Hawke"
+			}
+		},
 		"001F0F3B7F11E788": {
 			"english": {
 				"1761677138": "This dagger was once owned by the Dread Pirate known as \"The Black Almond.\" The hilt contains a small secret, one dose of lethal poison, to be used when eliminating a target requires subtlety instead of violence.",
@@ -199,9 +204,80 @@
 				"773185078": "Mark Faba was always a strange kid. Born to a firefighting father with a serious alcohol problem and an overworked mother working two jobs as a secretary in the iron and steel industry, Mark was left to his own devices from an early age. He spent his formative years living in his parents' basement and deeply embedded himself in the world of hobby electronics, phone phreaking and eventually computer hacking. <br><br> At 18, he found his calling as part of the underground computer hacking scene and sought to make himself a name by performing spectacular penetrations into corporate systems. After a series of hacks against the government, Faba was arrested by MI5 and placed in custody. Here, he was given a non-choice. Hone his skills with the Secret Service and work for England or face years of incarceration. <br><br> Faba spent two decades with MI5. He became an expert at demolitions and marksmanship. He learned infiltration techniques and grew his expertise at espionage, working for years on domestic surveillance projects aimed at journalists, politicians, corporate heads and members of the upper class. The stress and nature of his work got to Faba and one day, everything collapsed. <br><br> While on a mission to install surveillance equipment in the hotel suite of a visiting foreign diplomat, Faba was discovered. A struggle ensued and Faba ended up killing his intended surveillance target. Desperate and fearful of what might happen, Faba worked through the night to fake the circumstances around the man's death. Unfortunately, forensic experts at MI5 soon suspected foul play and as the evidence mounted, Faba felt the ground burn beneath him. In his desperation, he turned to an old bounty hunter connection and with their aid, Mark Faba disappeared from the world and was eventually presumed dead by his own hand. <br><br> Five years later, MI6 discovered a connection between of one their agents, who had been assassinated a year prior, and Mark Faba. Investigating the lead further provided vague indications that Faba was alive and was working as an assassin in various conflict zones around the world. An ICA contract was issued on Faba, requesting that he be terminated. The ICA sent one of their agents and eliminated Faba while on a mission in Somalia. However, Faba reappeared in Kosovo a few months later and so began one of the most enigmatic cases in ICA history. From that initial contract until present day, the ICA has confirmed the death of Faba more than 20 times and somehow, he keeps reappearing. <br><br> Faba has been given the nickname \"The Undying\" and has proven to be an un-erasable embarrassment for the ICA."
 			}
 		},
+		"0024A5A15AC9CC2F": {
+			"spanish": {
+				"1371055075": "«Mixtape 47»"
+			}
+		},
 		"003131BA6C4C5074": {
 			"english": {
-				"3203892346": "Coming from a proud lineage of Belgian war heroes—men who boldly defected to France in protest of King Leopold's surrender in World War II—Valliant was born with rebellion in his blood. For him, honor was everything, and he upheld his family's legacy with unwavering commitment. After graduating at the top of his class from Paris Sciences et Lettres, he took the next, inevitable step: enlisting in the French Foreign Legion. But Valliant’s ambitions ran darker than mere duty. He craved something beyond glory… he wanted power. <br><br>After his service, he transformed into a mercenary—a soldier of fortune—and soon caught the attention of the ICA, who wasted no time in recruiting him. Valliant rose quickly through their ranks, earning a deadly reputation as ICA’s most ruthless operative. Swift, precise, and merciless, he was everything they needed—and for Valliant, the money and the thrill of absolute control were… intoxicating. Killing came naturally to him. <br><br>But power, he realized, could be wielded in more ways than one. Playing multiple sides, manipulating his targets, Valliant’s games soon became a dangerous liability for ICA. When they uncovered his double-dealings, ICA took swift action, eliminating their top agent… or so they thought. <br><br>Now, he’s back, and this time, ICA’s very foundation is under threat…"
+				"605566503": "Boiling Point Reached",
+				"3053819346": "47 has been embedded undercover as a bodyguard in the ICA delegation.",
+				"3203892346": "Coming from a proud lineage of Belgian war heroes—men who boldly defected to France in protest of King Leopold's surrender in World War II—Valliant was born with rebellion in his blood. For him, honor was everything, and he upheld his family's legacy with unwavering commitment. After graduating at the top of his class from Paris Sciences et Lettres, he took the next, inevitable step: enlisting in the French Foreign Legion. But Valliant’s ambitions ran darker than mere duty. He craved something beyond glory… he wanted power. <br><br>After his service, he transformed into a mercenary—a soldier of fortune—and soon caught the attention of the ICA, who wasted no time in recruiting him. Valliant rose quickly through their ranks, earning a deadly reputation as ICA’s most ruthless operative. Swift, precise, and merciless, he was everything they needed—and for Valliant, the money and the thrill of absolute control were… intoxicating. Killing came naturally to him. <br><br>But power, he realized, could be wielded in more ways than one. Playing multiple sides, manipulating his targets, Valliant’s games soon became a dangerous liability for ICA. When they uncovered his double-dealings, ICA took swift action, eliminating their top agent… or so they thought. <br><br>Now, he’s back, and this time, ICA’s very foundation is under threat…",
+				"3818080128": "ICA Delegation"
+			},
+			"french": {
+				"605566503": "Point d'ébullition atteint"
+			},
+			"italian": {
+				"605566503": "Punto di ebollizione raggiunto"
+			},
+			"german": {
+				"605566503": "Siedepunkt erreicht"
+			},
+			"spanish": {
+				"605566503": "Punto de ebullición alcanzado"
+			},
+			"russian": {
+				"605566503": "Достигнута точка кипения"
+			},
+			"chineseSimplified": {
+				"605566503": "到达沸点"
+			},
+			"chineseTraditional": {
+				"605566503": "到達沸點"
+			},
+			"japanese": {
+				"605566503": "沸点に到達"
+			}
+		},
+		"0031D320C0F9FF08": {
+			"english": {
+				"3273557029": "Hawke's Bay"
+			},
+			"italian": {
+				"3273557029": "Hawke's Bay"
+			},
+			"spanish": {
+				"3273557029": "Bahía de Hawke"
+			}
+		},
+		"0034B7D0E44452E0": {
+			"spanish": {
+				"240629091": "<li>Completa 12 intensificaciones en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"313773456": "<li>Completa 35 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"324175323": "<li>Completa 3 intensificaciones en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"426380553": "<li>Completa 26 intensificaciones en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"597401889": "<li>Completa 10 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"683257056": "<li>Completa 45 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"1115577379": "<li>Completa 10 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"1134498920": "<li>Completa 18 intensificaciones en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"1230475225": "<li>Completa 30 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"1509398971": "<li>Completa 20 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"1601924251": "<li>Completa 25 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"2039837976": "<li>Completa 24 intensificaciones en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"2294532045": "<li>Completa 15 intensificaciones en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"2300743558": "<li>Completa 15 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"2485632830": "<li>Completa 20 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"2512844661": "<li>Completa 1 intensificación en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"2876713461": "<li>Completa 40 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"2999559869": "<li>Completa 21 intensificaciones en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"3303681677": "<li>Completa 5 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"3305858758": "<li>Completa 9 intensificaciones en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"3526811308": "<li>Completa 28 intensificaciones en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"3624818302": "<li>Completa 6 intensificaciones en estas ubicaciones:</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"3656326709": "<li>Completa 30 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>",
+				"3823468357": "<li>Completa 40 contratos destacados en estas ubicaciones:</li><li>París, Sapienza, Marrakech, Bangkok, Colorado, Hokkaido.</li><li>Bahía de Hawke, Miami, Santa Fortuna, Bombay, Whittleton Creek, Isla de Sgàil, Nueva York, Isla Haven.</li>"
 			}
 		},
 		"004757029ED4D7C4": {
@@ -209,6 +285,11 @@
 				"998061099": "A small plastic bag filled with nondescript pills, euphemistically dubbed \"Allergy Pills\" by the man outside the club entrance.",
 				"3503488150": "Bag of \"Allergy Pills\"",
 				"4183668711": "A man outside the entrance claims he can get you into the club if you help him find his missing \"Allergy Pills\". They're probably close by..."
+			}
+		},
+		"004B8C5124A49543": {
+			"spanish": {
+				"2231831317": "Traje de Código 47"
 			}
 		},
 		"004EC612565A38BD": {
@@ -239,6 +320,11 @@
 				"638095483": "The young Dame Barbara Keating, née Johnson, was from a modest working-class English background. Her father was a waiter at an expensive restaurant and unlike the rest of the fathers in their neighborhood, who wore overalls and worked on a factory line, Samuel Johnson left to work in a white shirt and a tuxedo. Seeing her father dressed up every morning and her mother’s glowing eyes as she served him his breakfast and brought him the paper was a source of pride to young Barbara. They may not have been better off than anybody else on the block - in fact they often struggled due to her father's heavy drinking - but in her esteem, they were still different.<br>Barbara was a stunning beauty, and at the age of 18 she caught the eye of a visiting businessman, Robert Keating, who was 25 years older than her and based halfway around the world in New Zealand. They married a few years later and when Keating had a heart attack in bed, Barbara sidelined Keating’s family and took control of her late husband's business interests. A tough and ruthless businesswoman, Barbara Keating built an empire, often leaving a fair bit of wreckage in her slipstream.<br>Much later, she made a foray into politics and was eventually appointed Minister of Trade and Foreign Affairs in her adopted homeland, before being given the honorary title Dame Barbara by the queen.<br>At the height of her powers, however, the newly-minted Dame became engulfed in a scandal and was forced to step down from her post. A charity she represented benifitting the homeless was found to have funneled donations into Dame Barbara’s own offshore holdings. To minimize the damage to herself, she drew on tabloid contacts and orchestrated an elaborate smear campaign against the director of the charity, a renowned but fragile poet and social organizer by the name of Jacqueline Vicar. The director was depicted as a blackmailer and conspirator, who aimed to entrap Dame Barbara in a scheme to pay off the mounting costs of Vicar's own private vices. Shortly thereafter, the director was involved in a conspicuously timed car accident, officially (and publicly) considered a suicide.<br>Now a somewhat more paranoid (and significantly more cautious) Dame Barbara is preparing for her political comeback, with help from an uncanny body double."
 			}
 		},
+		"005C45D871601753": {
+			"spanish": {
+				"4124322807": "<li>Inféctate con el virus.</li><li>Túmbate en una mesa de la morgue mientras estás infectado.</li><li>Completa la misión.</li>"
+			}
+		},
 		"005DE6FF4B418AF8": {
 			"english": {
 				"2935068597": "A ceremonial dagger."
@@ -250,6 +336,14 @@
 				"1442088885": "Eliminate Shahin Abdul-Barr Maalouf with a battle axe. <br>Eliminate Mahbub Jalal al Din Ganim while disguised as the Headmaster. <br>Break into the safe in the school and steal the contents. <br>Wild Card: Some things have been moved, removed or added to the level. <br>You are allowed one disguise change while playing the mission. If you change disguise more than once, you will fail the mission.",
 				"2209178792": "Eliminate Shahin Abdul-Barr Maalouf with a battle axe. <br>Eliminate Mahbub Jalal al Din Ganim while disguised as the Headmaster. <br>Break into the safe in the school and steal the contents.",
 				"2661831696": "Eliminate Shahin Abdul-Barr Maalouf with a battle axe. <br>Eliminate Mahbub Jalal al Din Ganim while disguised as the Headmaster. <br>Break into the safe in the school and steal the contents. <br>Wild Card: Some things have been moved, removed or added to the level."
+			}
+		},
+		"00643867EAFB7F36": {
+			"spanish": {
+				"409489378": "Ubicación de HITMAN 2: Bahía de Hawke, Nueva Zelanda<br>Disfruta de un paseo a la luz de la luna con el sonido de las olas de fondo por la costa de Bahía de Hawke (Nueva Zelanda) y, de noche, retírate a la terraza de una segura y lujosa casa de playa diseñada por el famoso arquitecto Oscar Wong.",
+				"1261797312": "¡El Paquete Bombay de HITMAN 2 te da acceso a todo el contenido permanente y futuro de las ubicaciones Bahía de Hawke y Bombay, así como al mapa de Asesino francotirador Himmelstein!<br><br>Si te gusta el Paquete Bombay, podrás mejorar a la experiencia completa de HITMAN 2 a precio reducido.",
+				"2787068754": "¡Obtén acceso gratuito a la primera misión de HITMAN 2! ¿Serás capaz de ayudar al Agente 47 a escapar del peligroso giro de los acontecimientos?<br>Disfruta de la rejugabilidad única de HITMAN 2, donde podrás experimentar, improvisar y completar todos los desafíos que Bahía de Hawke ofrece.",
+				"3175993088": "Bahía de Hawke"
 			}
 		},
 		"006F74FEE85A5CF3": {
@@ -272,7 +366,32 @@
 		"008322D98E1CFE04": {
 			"english": {
 				"611928695": "Old garden shears.",
-				"2913254817": "\"Good Quack Vol. 3\" VHS Tape"
+				"2913254817": "\"Good Quack Vol. 3\" VHS Tape",
+				"4164055027": "Enjoy this wonderful compilation chock full of footage of everyone’s favorite bird. Don’t have a VHS player? Then you can always use it to unleash your frustrations on your enemy!"
+			},
+			"french": {
+				"2913254817": "Cassette VHS \"Bon coin-coin vol. 3\""
+			},
+			"italian": {
+				"2913254817": "Videocassetta \"Buon qua-qua vol. 3\""
+			},
+			"german": {
+				"2913254817": "„Guter Quaken Vol. 3“ VHS-Kassette"
+			},
+			"spanish": {
+				"2913254817": "Cinta de vídeo «Buen cuac cuac, vol. 3»"
+			},
+			"russian": {
+				"2913254817": "Видеокассета «Хороший Кря-кря, часть 3»"
+			},
+			"chineseSimplified": {
+				"2913254817": "《好呱呱第3集》家庭录像带"
+			},
+			"chineseTraditional": {
+				"2913254817": "「好嘎嘎第3集」錄影帶"
+			},
+			"japanese": {
+				"2913254817": "「Good Quack Vol. 3」VHSテープ"
 			}
 		},
 		"0094D363985DA031": {
@@ -293,6 +412,16 @@
 			},
 			"russian": {
 				"1766502356": "Помогите Лукасу Грею похитить Константу [Дополнительно]"
+			}
+		},
+		"00A40B0195844051": {
+			"spanish": {
+				"3375291446": "Explota cinco globos."
+			}
+		},
+		"00C473591C72C358": {
+			"english": {
+				"3352206434": "KAI Malfunction"
 			}
 		},
 		"00C4FB89CD2F7B77": {
@@ -420,8 +549,17 @@
 			}
 		},
 		"00DC202021F89A51": {
+			"spanish": {
+				"634477522": "<li>Completa «Explosiones desatadas».</li><li>Elimina a todos los guardias del tren durante la misión «Intocable» en los Cárpatos, Rumanía.</li><li>Acaba con todo con un viaje por los recuerdos.</li>",
+				"1364212078": "Completa todos los desafíos de Código 47. <li>El Dragón Rojo</li><li>Saluda a mi amiguito</li><li>Tradiciones del oficio</li><li>Explosiones desatadas</li><li>La artimaña</li>",
+				"2799138235": "Tradiciones del oficio",
+				"3625841451": "<li>Completa «Tradiciones del oficio».</li><li>Elimina a 5 agentes de la ICA con explosivos durante la misión «Superdepredador» en Berlín, Alemania.</li><li>Hay que conseguir todas las eliminaciones en una misma partida.</li>",
+				"4081166313": "<li>Completa «Saluda a mi amiguito».</li><li>Elimina a cualquier objetivo en Bangkok, Tailandia ahogándolo.</li>"
+			}
+		},
+		"00E45529FDC93B59": {
 			"english": {
-				"634477522": "<li>Complete \"Explosions Run Loose\"</li><li>Eliminate all guards on the train during the Untouchable mission in the Carpathian Mountains, Romania</li><li>End it all by taking a trip down memory lane</li>"
+				"2571192323": "<li>[REDACTED]</li>"
 			}
 		},
 		"00E4A105055DA583": {
@@ -461,6 +599,11 @@
 		"00E8D1F727A21C56": {
 			"english": {
 				"512609165": "Protected<br>Reservoir"
+			}
+		},
+		"00EBEB2121174D0B": {
+			"spanish": {
+				"85490831": "Ubicación de HITMAN 2: Bahía de Hawke, Nueva Zelanda<br>Disfruta de un paseo a la luz de la luna con el sonido de las olas de fondo por la costa de Bahía de Hawke (Nueva Zelanda) y, de noche, retírate a la terraza de una segura y lujosa casa de playa diseñada por el famoso arquitecto Oscar Wong."
 			}
 		},
 		"00F3D25FC3719890": {
@@ -519,11 +662,6 @@
 				"2076817645": "как операционист",
 				"2269581433": "как специалист по инвестициям",
 				"4099960753": "как кандидат"
-			}
-		},
-		"00C473591C72C358": {
-			"english": {
-				"3352206434": "KAI Malfunction"
 			}
 		}
 	}


### PR DESCRIPTION
- see #180 for even more details
- remove officially fixed English localisation for `CHALLENGEPACK_ARGENTUM_WOLVERINEFINISHER_DESC`
- add translations for "Good Quack Vol. 3" VHS Tape
- change "chuck full" to "chock full" in the VHS description
- fix capitalization of "ICA Delegation" starting location
- change "imbedded" to "embedded" in ICA Delegation description
- change The Splitter's cloning tanks picture-in-picture's generic "Boil" text to "Boiling Point Reached" with translations
- change "A Matter of Loyalty" challenge description to `<li>[REDACTED]</li>` to match other redacted challenges
- add many Spanish localisation changes based on ones provided by IWILLCRAFT
- change more Spanish localisations from "Hawke's Bay" to "Bahía de Hawke"
- sort manifest localisationOverrides items