### PR TITLE
feat: fix consulate guard act clipping in level geometry

### DIFF
--- a/content/SmallFixes/chunk25/ConsulateGuardActFix/npc_mission_spider.entity.patch.json
+++ b/content/SmallFixes/chunk25/ConsulateGuardActFix/npc_mission_spider.entity.patch.json
@@ -1,0 +1,29 @@
+{
+	"tempHash": "004868F794D35933",
+	"tbluHash": "006E467BCDA40509",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"ec00b7f626ffa381",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_mTransform",
+						"value": {
+							"rotation": {
+								"x": -0.0,
+								"y": 0.0,
+								"z": 176.54147598292263
+							},
+							"position": {
+								"x": -18.16695976257324,
+								"y": -104.101,
+								"z": 7.400050163269043
+							}
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Moves the end point of the act so that it doesn't clip into the level geometry (located in the upstairs consulate offices)