### PR TITLE
feat: remove a now-redundant DIF fix for Miami and give 47 his head back when disguised as Marshall v4

### DIFF
--- a/content/DIF/chunk9/Miami/RaceMarshallV0Hero.entity.patch.json
+++ b/content/DIF/chunk9/Miami/RaceMarshallV0Hero.entity.patch.json
@@ -1,6 +1,0 @@
-{
-	"tempHash": "006EBD8DA925F06C",
-	"tbluHash": "0016A831BF892C21",
-	"patch": [{ "SubEntityOperation": ["ac9b599754e2420b", { "RemovePropertyByName": "Texture2D_01" }] }],
-	"patchVersion": 6
-}

--- a/content/DIF/chunk9/Miami/RaceMarshallv4HeadFix.entity.patch.json
+++ b/content/DIF/chunk9/Miami/RaceMarshallv4HeadFix.entity.patch.json
@@ -1,0 +1,22 @@
+{
+	"tempHash": "00C31C19EBD97713",
+	"tbluHash": "005E7C72D4EBEF7D",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"1f80c26ee141b917",
+				{
+					"PatchArrayPropertyValue": [
+						"m_aBodyParts",
+						[
+							{
+								"AddItemAfter": ["829b02357c5f5573", "1e67256c4eecd180"]
+							}
+						]
+					]
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Overriding the color of 47's jumpsuit as v0 is no longer necessary

47-as-Marshall v4 lost his head in the latest patch for some reason, so I've made another patch to add it back. This will likely be fixed soon, so it's not lumped in with the regular DIF v4 patch