### PR TITLE
fix: correct a mistakenly unmodified subtitle in a previous fix for The Splitter

### DIFF
--- a/content/SmallFixes/chunk6/SplitterSubtitleFixes/006112688578C526.dlge.json
+++ b/content/SmallFixes/chunk6/SplitterSubtitleFixes/006112688578C526.dlge.json
@@ -10,7 +10,7 @@
 		"defaultWav": "[assembly:/sound/wwise/originals/voices/english(us)/wet/43000_elusive/lambic/43750_story/dr43780_lptrshcomp_et_lambic_004.wav].pc_wes",
 		"defaultFfx": "[assembly:/_pro/facefx/exported_animation/english(us)/wet/43000_elusive/lambic/43750_story/dr43780_lptrshcomp_et_lambic_004.animset].pc_animset",
 		"languages": {
-			"en": "//(0,30)\\\\It is, ne's pa?",
+			"en": "//(0,30)\\\\It is, n'est-ce pas?",
 			"fr": "//(0,30)\\\\Ça, vous pouvez le dire.",
 			"it": "//(0,30)\\\\Vero, n'est-ce pas?",
 			"de": "//(0,30)\\\\Das ist es, n’est-ce pas?",

--- a/content/SmallFixes/chunk6/SplitterSubtitleFixes/006112688578C526.dlge.json
+++ b/content/SmallFixes/chunk6/SplitterSubtitleFixes/006112688578C526.dlge.json
@@ -10,7 +10,7 @@
 		"defaultWav": "[assembly:/sound/wwise/originals/voices/english(us)/wet/43000_elusive/lambic/43750_story/dr43780_lptrshcomp_et_lambic_004.wav].pc_wes",
 		"defaultFfx": "[assembly:/_pro/facefx/exported_animation/english(us)/wet/43000_elusive/lambic/43750_story/dr43780_lptrshcomp_et_lambic_004.animset].pc_animset",
 		"languages": {
-			"en": "//(0,30)\\\\It is, n'est-cepas?",
+			"en": "//(0,30)\\\\It is, n'est-ce pas?",
 			"fr": "//(0,30)\\\\Ça, vous pouvez le dire.",
 			"it": "//(0,30)\\\\Vero, n'est-ce pas?",
 			"de": "//(0,30)\\\\Das ist es, n’est-ce pas?",

--- a/content/SmallFixes/chunk6/SplitterSubtitleFixes/006112688578C526.dlge.json
+++ b/content/SmallFixes/chunk6/SplitterSubtitleFixes/006112688578C526.dlge.json
@@ -10,7 +10,7 @@
 		"defaultWav": "[assembly:/sound/wwise/originals/voices/english(us)/wet/43000_elusive/lambic/43750_story/dr43780_lptrshcomp_et_lambic_004.wav].pc_wes",
 		"defaultFfx": "[assembly:/_pro/facefx/exported_animation/english(us)/wet/43000_elusive/lambic/43750_story/dr43780_lptrshcomp_et_lambic_004.animset].pc_animset",
 		"languages": {
-			"en": "//(0,30)\\\\It is, n'est-ce pas?",
+			"en": "//(0,30)\\\\It is, n'est-cepas?",
 			"fr": "//(0,30)\\\\Ça, vous pouvez le dire.",
 			"it": "//(0,30)\\\\Vero, n'est-ce pas?",
 			"de": "//(0,30)\\\\Das ist es, n’est-ce pas?",


### PR DESCRIPTION
In #267 I fixed many errors in the subtitles for The Splitter. I *intended* to fix one where "n'est-ce pas" was written as "ne's pa", but apparently I mistakenly included an unmodified version of the `dlge.json`. This will correct that error, and the subtitle.

May Ne's pa rest in peace. I hope Ne's ma is doing well in these difficult times.