### PR TITLE
fix: update and re-add CrossGuardv4 DIF fix

### DIFF
--- a/content/DIF/chunk1/Bangkok/CrossGuardV4Hero.entity.patch.json
+++ b/content/DIF/chunk1/Bangkok/CrossGuardV4Hero.entity.patch.json
@@ -1,0 +1,24 @@
+{
+	"tempHash": "00BAD7FE78C21B1A",
+	"tbluHash": "00B469C3FDA39438",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"70962007579f2d65",
+				{
+					"PatchArrayPropertyValue": [
+						"m_aBodyParts",
+						[
+							{ "RemoveItemByValue": "9b4543617cc40ba3" },
+							{ "AddItemAfter": ["e79c06c006ee193e", "c6d4e11024a51ef1"] },
+							{ "RemoveItemByValue": "ba5467b87ee0f157" },
+							{ "AddItemAfter": ["fd11ca899f5967bc", "c0b93e1eceebbc33"] },
+							{ "RemoveItemByValue": "74fc996b5bcfbf8a" }
+						]
+					]
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Was removed in a previous update (had no PR so can't link it) due to being broken after IO removed the entities it was referencing to change the necessary body parts. (Three types of ring, no longer present in any entity)