### PR TITLE
fix: add content/FractureLiquidColor to the content folders list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
 	"contentFolders": [
 		"content/Audio",
 		"content/DIF",
+		"content/FractureLiquidColor",
 		"content/MovieSetLamp",
 		"content/OACFixes",
 		"content/OutfitFilterFixes",


### PR DESCRIPTION
refs #391 

This fix was previously not being loaded due to... me not remembering that it needed to be in there... :p