### PR TITLE
feat: stop Elite Guards in Isle of Sgàil from opening fire on 47 immediately rather than going into the follow-warn state

### DIFF
--- a/content/SmallFixes/chunk1/SgailBerserkGuardsFix/SgailBerserkGuardsFix.entity.patch.json
+++ b/content/SmallFixes/chunk1/SgailBerserkGuardsFix/SgailBerserkGuardsFix.entity.patch.json
@@ -1,0 +1,10 @@
+{
+	"tempHash": "00E95B973DD44755",
+	"tbluHash": "00FF110EBD82A8FC",
+	"patch": [
+		{
+			"SubEntityOperation": ["15ad4877e2b8c4bc", { "RemovePropertyByName": "m_eActorRank" }]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Without patch:

https://github.com/user-attachments/assets/36561dc3-0dff-439f-90ff-1e84b9065878

With patch:

https://github.com/user-attachments/assets/040e9bc9-358f-4262-ad70-62235d505c4f


