### PR TITLE
feat: fix Bat Shuriken and some other shurikens to count as lethal melee for the purposes of some escalation conditions

### DIFF
--- a/content/REPO/chunk0/ShurikenMeleeFix.repository.json
+++ b/content/REPO/chunk0/ShurikenMeleeFix.repository.json
@@ -1,0 +1,8 @@
+{
+	"92330cd4-1bb1-419e-98d3-ef26631504bf": { "OnlineTraits": ["melee_lethal", "throw_lethal_deprecated"] },
+	"490493af-64db-4692-b32e-d691d86bc82a": { "OnlineTraits": ["melee_lethal", "throw_lethal_deprecated"] },
+	"e55eb9a4-e79c-43c7-970b-79e94e7683b7": { "OnlineTraits": ["melee_lethal", "throw_lethal_deprecated"] },
+	"cad726d7-331d-4601-9723-6b8a17e5f91b": { "OnlineTraits": ["melee_lethal", "throw_lethal_deprecated"] },
+	"1a852006-e632-401f-aedc-d0cf76521b1f": { "OnlineTraits": ["melee_lethal", "throw_lethal_deprecated"] },
+	"33c16292-7f60-4f0b-8ea0-bae80bc31d1a": { "OnlineTraits": ["melee_lethal", "throw_lethal_deprecated"] }
+}


### PR DESCRIPTION
Fixes #364 by switching the order of the REPO items. Does not fully remove the deprecated thrown weapon tag just in case it's used somewhere.