### PR TITLE
feat: fix location of exit sign

### DIFF
--- a/content/SmallFixes/chunk26/ExitSignFix/sign_exit_a_00.entity.patch.json
+++ b/content/SmallFixes/chunk26/ExitSignFix/sign_exit_a_00.entity.patch.json
@@ -1,0 +1,25 @@
+{
+	"tempHash": "008393F4B010DC2C",
+	"tbluHash": "00A97B3B6EAFB9E3",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"3857413d4b3f110e",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_mTransform",
+						"value": {
+							"rotation": { "x": -0.0, "y": 0.0, "z": -90 },
+							"position": {
+								"x": 6.1197815,
+								"y": 2.2996902,
+								"z": 2.5368130207061768
+							}
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Fixes #461

Move exit sign to the room it is parented to

unsure of the original idea behind it, but I moved and rotated the sign to face the door
![image](https://github.com/user-attachments/assets/35c41099-f1fb-4aad-b9c0-f153b9b9af6a)
![HITMAN3_SQtc5S961I](https://github.com/user-attachments/assets/a31fb207-7dad-4be5-911c-f5dbfeb8cad0)
![HITMAN3_vF0GKamhjW](https://github.com/user-attachments/assets/aa95482e-ed74-46db-9e21-ce95a5fb01f8)
