### PR TITLE
feat: fixed clipping of evac phone in consulate

### DIFF
--- a/content/SmallFixes/chunk25/StrandbergEvacPhoneClipping/strandberg_phone_clipping.entity.patch.json
+++ b/content/SmallFixes/chunk25/StrandbergEvacPhoneClipping/strandberg_phone_clipping.entity.patch.json
@@ -1,0 +1,29 @@
+{
+	"tempHash": "004868F794D35933",
+	"tbluHash": "006E467BCDA40509",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"b8682e77e3a68367",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_mTransform",
+						"value": {
+							"rotation": {
+								"x": -0.0,
+								"y": 0.0,
+								"z": -97.604082768013
+							},
+							"position": {
+								"x": -2.7115960121154785,
+								"y": 2.6552579402923584,
+								"z": 0.04
+							}
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Moved the phone slightly upwards so that it doesn't clip with the table anymore

![HITMAN_pcRVb8HQCY](https://github.com/user-attachments/assets/e7263117-3c65-40b8-a935-140bc1e64f6b)
![HITMAN3_Vj1HtyCfrW](https://github.com/user-attachments/assets/1f1435e1-473a-408b-a36d-8f6931c79050)