### PR TITLE
fix: correctly apply Italian localisation for some disguises

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -539,7 +539,7 @@
 				"3651785796": "as an Armored Knight",
 				"4098699491": "as the Master of Ceremonies"
 			},
-			"it": {
+			"italian": {
 				"639433783": "come cameriere",
 				"1401254989": "come Blake Nathaniel",
 				"1987771976": "come Jebediah Block",


### PR DESCRIPTION
Currently the key used is `it`, which will have no effect as SMF simply ignores localisation keys it doesn't recognise.