### PR TITLE
feat: correct description for the Purple Streak Fiber Wire

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -466,31 +466,40 @@
 				"611928695": "Old garden shears.",
 				"2913254817": "\"Good Quack Vol. 3\" VHS Tape",
 				"4091088772": "Everyone knows that silver is so last year… so why not impress and make your fellow coin collectors twitch with envy with this elegant, yet simple purple coin.",
-				"4164055027": "Enjoy this wonderful compilation chock full of footage of everyone’s favorite bird. Don’t have a VHS player? Then you can always use it to unleash your frustrations on your enemy!"
+				"4164055027": "Enjoy this wonderful compilation chock full of footage of everyone’s favorite bird. Don’t have a VHS player? Then you can always use it to unleash your frustrations on your enemy!",
+				"1772560051": "For the hitman who dares to be bold. This beautiful purple fiber wire set will give your execution that certain \"Je ne sais quoi\". The only downside? Your victims will never know they went down in style."
 			},
 			"french": {
-				"2913254817": "Cassette VHS \"Bon coin-coin vol. 3\""
+				"2913254817": "Cassette VHS \"Bon coin-coin vol. 3\"",
+				"1772560051": "For the hitman who dares to be bold. This beautiful purple fiber wire set will give your execution that certain \"Je ne sais quoi\". The only downside? Your victims will never know they went down in style."
 			},
 			"italian": {
-				"2913254817": "Videocassetta \"Buon qua-qua vol. 3\""
+				"2913254817": "Videocassetta \"Buon qua-qua vol. 3\"",
+				"1772560051": "For the hitman who dares to be bold. This beautiful purple fiber wire set will give your execution that certain \"Je ne sais quoi\". The only downside? Your victims will never know they went down in style."
 			},
 			"german": {
-				"2913254817": "„Guter Quaken Vol. 3“ VHS-Kassette"
+				"2913254817": "„Guter Quaken Vol. 3“ VHS-Kassette",
+				"1772560051": "For the hitman who dares to be bold. This beautiful purple fiber wire set will give your execution that certain \"Je ne sais quoi\". The only downside? Your victims will never know they went down in style."
 			},
 			"spanish": {
-				"2913254817": "Cinta de vídeo «Buen cuac cuac, vol. 3»"
+				"2913254817": "Cinta de vídeo «Buen cuac cuac, vol. 3»",
+				"1772560051": "For the hitman who dares to be bold. This beautiful purple fiber wire set will give your execution that certain \"Je ne sais quoi\". The only downside? Your victims will never know they went down in style."
 			},
 			"russian": {
-				"2913254817": "Видеокассета «Хороший Кря-кря, часть 3»"
+				"2913254817": "Видеокассета «Хороший Кря-кря, часть 3»",
+				"1772560051": "For the hitman who dares to be bold. This beautiful purple fiber wire set will give your execution that certain \"Je ne sais quoi\". The only downside? Your victims will never know they went down in style."
 			},
 			"chineseSimplified": {
-				"2913254817": "《好呱呱第3集》家庭录像带"
+				"2913254817": "《好呱呱第3集》家庭录像带",
+				"1772560051": "For the hitman who dares to be bold. This beautiful purple fiber wire set will give your execution that certain \"Je ne sais quoi\". The only downside? Your victims will never know they went down in style."
 			},
 			"chineseTraditional": {
-				"2913254817": "「好嘎嘎第3集」錄影帶"
+				"2913254817": "「好嘎嘎第3集」錄影帶",
+				"1772560051": "For the hitman who dares to be bold. This beautiful purple fiber wire set will give your execution that certain \"Je ne sais quoi\". The only downside? Your victims will never know they went down in style."
 			},
 			"japanese": {
-				"2913254817": "「Good Quack Vol. 3」VHSテープ"
+				"2913254817": "「Good Quack Vol. 3」VHSテープ",
+				"1772560051": "For the hitman who dares to be bold. This beautiful purple fiber wire set will give your execution that certain \"Je ne sais quoi\". The only downside? Your victims will never know they went down in style."
 			}
 		},
 		"0094D363985DA031": {


### PR DESCRIPTION
Original: 
> For the Hitman who dares to be bold. This beautiful purple fibre wire set will give your execution that certain \"Che nes cet quoi”. The only downside? Your victems will never know they went down in style.

Changed: 
> For the hitman who dares to be bold. This beautiful purple fiber wire set will give your execution that certain \"Je ne sais quoi\". The only downside? Your victims will never know they went down in style.


This makes the following changes:

- "Hitman" is now lowercase as it isn't a proper noun.
- "Fibre wire" has been changed to "fiber wire" to align with the item's name, and the spelling used for other fiber wires in the past
- The meaningless "French" text of "Che nes cet quoi" has been changed to "Je ne sais quoi" which actually means something
- "Victems" has been changed to "victims"

This change has also been copied to all languages, since that's also what IO did. Translation submissions from fluent speakers are welcome, as always.