### PR TITLE
feat: fixes the alignment of the ventilation grate hatch in hawke's bay

### DIFF
--- a/content/SmallFixes/chunk20/NewZealandGrateAlignmentFix/Setpiece_NewZea_Grate_Ledge.entity.patch.json
+++ b/content/SmallFixes/chunk20/NewZealandGrateAlignmentFix/Setpiece_NewZea_Grate_Ledge.entity.patch.json
@@ -1,0 +1,25 @@
+{
+	"tempHash": "00EA24C4F764DED9",
+	"tbluHash": "0080CDE1C214F48A",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"dbdddc9e4c01acf7",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_mTransform",
+						"value": {
+							"rotation": { "x": -0.0, "y": 0.0, "z": -0.0 },
+							"position": {
+								"x": -0.004149999935179949,
+								"y": -0.07000000029802322,
+								"z": 0.7149720191955566
+							}
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Before:
<img width="590" height="422" alt="image" src="https://github.com/user-attachments/assets/5ec9790f-83e8-4ad7-9935-805e173d587c" />

after:
<img width="1073" height="806" alt="image-1" src="https://github.com/user-attachments/assets/3707cdbf-4ad1-4650-b536-7ba2621c5079" />

(sorry about the different angles)