### PR TITLE
feat: edit printworker scarf material to support transparency

### DIFF
--- a/content/SmallFixes/chunk25/PrintworkerScarfFix/male_reg_printworker_01_hat_01.material.json
+++ b/content/SmallFixes/chunk25/PrintworkerScarfFix/male_reg_printworker_01_hat_01.material.json
@@ -1,0 +1,205 @@
+{
+    "$schema": "https://glaciermodding.org/schemas/material.schema.json",
+    "MATI": "[assembly:/_pro/characters/assets/workers/printworker_01/materials/male_reg_printworker_01_hat_01.mi].pc_mi",
+    "MATT": "[assembly:/_pro/characters/assets/workers/printworker_01/materials/male_reg_printworker_01_hat_01.mi].pc_entitytype",
+    "MATB": "[assembly:/_pro/characters/assets/workers/printworker_01/materials/male_reg_printworker_01_hat_01.mi].pc_entityblueprint",
+    "MATE": "[[assembly:/_pro/characters/materialclasses/basic_discard.materialclass].fx](dx11).pc_mate",
+    "ERES": "[assembly:/_pro/effects/templates/materialdescriptors/fx_md_char_cloth.template?/fx_md_char_cloth.entitytemplate].pc_entityresource",
+    "TYPE": "Standard",
+    "Material": {
+        "Instance": [
+            {
+                "Name": "male_reg_printworker_01_hat_01.mi",
+                "Tags": "",
+                "Binder": [
+                    {
+                        "Render State": [
+                            {
+                                "Name": "RenderState",
+                                "Enabled": 1,
+                                "Blend Enabled": 0,
+                                "Decal Blend Diffuse": 0,
+                                "Decal Blend Normal": 0,
+                                "Decal Blend Specular": 0,
+                                "Decal Blend Roughness": 0,
+                                "Decal Blend Emission": 0,
+                                "Alpha Test Enabled": 0,
+                                "Alpha Reference": 255,
+                                "Fog Enabled": 1,
+                                "Culling Mode": "DontCare",
+                                "Z Bias": 0,
+                                "Z Offset": 0.0,
+                                "Subsurface Red": 0.0,
+                                "Subsurface Green": 0.0,
+                                "Subsurface Blue": 0.0,
+                                "Subsurface Value": 0.0
+                            }
+                        ],
+                        "Texture": [
+                            {
+                                "Name": "mapTexture2DNormal_01",
+                                "Enabled": 1,
+                                "Texture Id": "[assembly:/_pro/characters/assets/workers/printworker_01/textures/male_reg_printworker_01_hat_01.texture?/normal_a.tex](asnormalmap).pc_tex",
+                                "Tiling U": "",
+                                "Tiling V": "",
+                                "Type": "AsNormalMap"
+                            },
+                            {
+                                "Name": "mapTexture2D_03",
+                                "Enabled": 1,
+                                "Texture Id": "[assembly:/_pro/characters/assets/workers/printworker_01/textures/male_reg_printworker_01_hat_01.texture?/specular_a.tex](ascolormap).pc_tex",
+                                "Tiling U": "",
+                                "Tiling V": "",
+                                "Type": "AsColorMap"
+                            },
+                            {
+                                "Name": "mapTexture2D_01",
+                                "Enabled": 1,
+                                "Texture Id": "[assembly:/_pro/characters/assets/workers/printworker_01/textures/male_reg_printworker_01_hat_01.texture?/diffuse_a.tex](ascolormap).pc_tex",
+                                "Tiling U": "",
+                                "Tiling V": "",
+                                "Type": "AsColorMap"
+                            }
+                        ],
+                        "Float Value": [
+                            {
+                                "Name": "ConstantVector1D_06_Value",
+                                "Enabled": 1,
+                                "Value": 1.0
+                            },
+                            {
+                                "Name": "gm_mTransform2D_01",
+                                "Enabled": 1,
+                                "Value": [
+                                    1.0,
+                                    -0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0,
+                                    0.0,
+                                    0.0
+                                ]
+                            },
+                            {
+                                "Name": "ConstantVector1D_04_Value",
+                                "Enabled": 1,
+                                "Value": 0.0
+                            },
+                            {
+                                "Name": "ConstantVector1D_05_Value",
+                                "Enabled": 1,
+                                "Value": 0.550000011920929
+                            },
+                            {
+                                "Name": "ConstantVector1D_03_Value",
+                                "Enabled": 1,
+                                "Value": 1.0
+                            },
+                            {
+                                "Name": "ConstantVector1D_01_Value",
+                                "Enabled": 1,
+                                "Value": 0.5
+                            },
+                            {
+                                "Name": "Diffuse_Saturation_01_Value",
+                                "Enabled": 1,
+                                "Value": 1.0
+                            },
+                            {
+                                "Name": "Diffuse_Hue_Shift_01_Value",
+                                "Enabled": 1,
+                                "Value": 0.0
+                            },
+                            {
+                                "Name": "ConstantVector1D_02_Value",
+                                "Enabled": 1,
+                                "Value": 0.5
+                            }
+                        ],
+                        "Color": [
+                            {
+                                "Name": "Diffuse_Color_01_Value",
+                                "Enabled": 1,
+                                "Value": [
+                                    1.0,
+                                    1.0,
+                                    1.0
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "Overrides": {
+        "Texture": {
+            "Texture2DNormal_01": "[assembly:/_pro/characters/assets/workers/printworker_01/textures/male_reg_printworker_01_hat_01.texture?/normal_a.tex](asnormalmap).pc_tex",
+            "Texture2D_03": "[assembly:/_pro/characters/assets/workers/printworker_01/textures/male_reg_printworker_01_hat_01.texture?/specular_a.tex](ascolormap).pc_tex",
+            "Texture2D_01": "[assembly:/_pro/characters/assets/workers/printworker_01/textures/male_reg_printworker_01_hat_01.texture?/diffuse_a.tex](ascolormap).pc_tex"
+        },
+        "ConstantVector1D_06_Value": 1.0,
+        "ConstantVector1D_04_Value": 0.0,
+        "ConstantVector1D_05_Value": 0.550000011920929,
+        "ConstantVector1D_03_Value": 1.0,
+        "ConstantVector1D_01_Value": 0.5,
+        "Color": {
+            "Diffuse_Color_01_Value": [
+                1.0,
+                1.0,
+                1.0
+            ]
+        },
+        "Diffuse_Saturation_01_Value": 1.0,
+        "Diffuse_Hue_Shift_01_Value": 0.0,
+        "ConstantVector1D_02_Value": 0.5
+    },
+    "Flags": {
+        "Class": {
+            "REFLECTION2D": false,
+            "REFRACTION2D": false,
+            "LIGHTING": true,
+            "EMISSIVE": false,
+            "DISCARD": true,
+            "LM_SKIN": false,
+            "PRIMCLASS_STANDARD": true,
+            "PRIMCLASS_LINKED": false,
+            "PRIMCLASS_WEIGHTED": false,
+            "DOFOVERRIDE": false,
+            "USES_DEFAULT_VS": true,
+            "USES_SPRITE_SA_VS": false,
+            "USES_SPRITE_AO_VS": false,
+            "ALPHA": false,
+            "USES_SIMPLE_SHADER": true,
+            "DISABLE_INSTANCING": false,
+            "LM_HAIR": false,
+            "SAMPLE_LIGHTING": false,
+            "HORIZONMAPPING": false,
+            "UNKNOWN_3": false,
+            "UNKNOWN_4": false,
+            "UNKNOWN_5": false
+        },
+        "Instance": {
+            "OPAQUE_EMISSIVE": false,
+            "TRANS_EMISSIVE": false,
+            "TRANSADD_EMISSIVE": false,
+            "TRANSALL": false,
+            "OPAQUE_LIT": true,
+            "TRANS_LIT": false,
+            "DECAL": false,
+            "REFRACTIVE": false,
+            "LM_SKIN": false,
+            "LM_HAIR": false,
+            "FORCE_EMISSIVE": false,
+            "DISABLE_SHADER_LOD": true,
+            "DISCARD": false,
+            "DECAL_EMISSIVE": false,
+            "DECAL_ALL": false,
+            "WATER_CLIPPING": false,
+            "SAMPLE_LIGHTING": false,
+            "EXCLUDE_GLOBAL_SHADOWS": false,
+            "ALL": false
+        }
+    }
+}


### PR DESCRIPTION
Fixes #521
Switched MATE from "basic" to "basic_discard", added a "ConstantVector1D_02_Value" property and enabled "DISCARD" in the flags

<img width="1920" height="1080" alt="printworker_after" src="https://github.com/user-attachments/assets/93d2b629-74b8-47e7-98c2-32826b2e8edf" />