### PR TITLE
fix: remove more redundant fixes

### DIFF
--- a/content/DartmoorHarbingerStaff/chunk3/OUTFIT_Bulldog_Worker_MansionStaff_F_Actor_v5.entity.json
+++ b/content/DartmoorHarbingerStaff/chunk3/OUTFIT_Bulldog_Worker_MansionStaff_F_Actor_v5.entity.json
@@ -563,7 +563,6 @@
 			"resource": "[assembly:/_pro/characters/assets/_genericparts/skin/textures/skin_detail_h3.texture?/skin_normal_detail.tex](asnormalmap).pc_tex",
 			"flag": "5F"
 		},
-		{ "resource": "007AB310F7DB3836", "flag": "5F" },
 		{
 			"resource": "[assembly:/_pro/characters/assets/_genericparts/skin/textures/skin_detail_h3.texture?/skin_variance_detail.tex](ascolormap).pc_tex",
 			"flag": "5F"

--- a/manifest.json
+++ b/manifest.json
@@ -606,11 +606,6 @@
 				"3375291446": "Explota cinco globos."
 			}
 		},
-		"00C473591C72C358": {
-			"english": {
-				"3352206434": "KAI Malfunction"
-			}
-		},
 		"00C4FB89CD2F7B77": {
 			"english": {
 				"639433783": "as a Waiter",


### PR DESCRIPTION
One undocumented official fix (KAI Malfunction text, #321) and a vanilla quirk present in a reverted entity (#558)