### PR TITLE
feat: stop sentry in Sgàil from wrongly denying access to the Helipad

### DIFF
--- a/content/SmallFixes/chunk15/SentryFixGalleryToHelipad/SentryFixGalleryToHelipad.entity.patch.json
+++ b/content/SmallFixes/chunk15/SentryFixGalleryToHelipad/SentryFixGalleryToHelipad.entity.patch.json
@@ -1,0 +1,25 @@
+{
+	"tempHash": "009792BC33857D2A",
+	"tbluHash": "00B8EE64611429CC",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"c6a43cc64804c23a",
+				{
+					"PatchArrayPropertyValue": [
+						"m_aDisguisesAllowed",
+						[
+							{
+								"AddItemAfter": ["6b65f9008ce13e0d", "f2ebc39f8ed4b3c7"]
+							},
+							{
+								"AddItemAfter": ["6b65f9008ce13e0d", "f758324ee6d0ad5a"]
+							}
+						]
+					]
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
From #584 

*Architects and Castle Staff are not trespassing in the Helipad area unless they attempt to access it with [the door from the Gallery to the Helipad], where they will instead be shot for refusing the sentry's (incorrect) denial.*

This will fix the above issue by simply adding the two disguises into the sentry's allowed disguises list.