### PR TITLE
feat: fix "The Sapienza FC-Sanguine Boot" so it's no longer illegal in casual mode

### DIFF
--- a/content/SmallFixes/chunk0/SapienzaFCSanguineBoot_LegalityFix/Prop_Melee_Football_Shoe_Runtime.entity.patch.json
+++ b/content/SmallFixes/chunk0/SapienzaFCSanguineBoot_LegalityFix/Prop_Melee_Football_Shoe_Runtime.entity.patch.json
@@ -1,0 +1,24 @@
+{
+	"tempHash": "0083AC6026DEAB82",
+	"tbluHash": "006EBD033ACCE411",
+	"patch": [
+		{
+			"AddEntity": [
+				"cafecdf0fb53aaf5",
+				{
+					"parent": "f8d2dde629637871",
+					"name": "Keyword_ITEMRULE_LEGAL",
+					"factory": "[assembly:/_pro/design/gamecore/keywords/keyworditems.template?/keyword_itemrule_legal.entitytemplate].pc_entitytype",
+					"blueprint": "[assembly:/_pro/design/gamecore/keywords/keyworditems.template?/keyword_itemrule_legal.entitytemplate].pc_entityblueprint",
+					"properties": {
+						"m_aHolders": {
+							"type": "TArray<SEntityTemplateReference>",
+							"value": ["ed4fbbb8235fcaae"]
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
… casual mode (fixes #587)
Before:
<img width="833" height="214" alt="image" src="https://github.com/user-attachments/assets/f058570b-afda-4fbe-8c48-f370738e945c" />

After:
<img width="844" height="213" alt="image" src="https://github.com/user-attachments/assets/a9b9c488-e143-47c2-a543-b50fa5c6562f" />

It was just missing the ITEMRULE_LEGAL keyword.