### PR TITLE
feat: bump priority of flavor idles to make them play more consistently

### DIFF
--- a/content/SmallFixes/chunk0/FlavorIdleFix/statemachinecoordinator.entity.patch.json
+++ b/content/SmallFixes/chunk0/FlavorIdleFix/statemachinecoordinator.entity.patch.json
@@ -3,6 +3,9 @@
 	"tbluHash": "00B35AB8FFF33681",
 	"patch": [
 		{
+			"SubEntityOperation": ["6ad56c220d337174", { "RemovePropertyByName": "m_eActorNearbyRequirements" }]
+		},
+		{
 			"SubEntityOperation": [
 				"6ad56c220d337174",
 				{
@@ -12,6 +15,133 @@
 					}
 				}
 			]
+		},
+		{
+			"SubEntityOperation": [
+				"d45304b0f7b652eb",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"d45304b0f7b652eb",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fCooldownForThis",
+						"value": 15.0
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": ["b44a356315b341eb", { "RemovePropertyByName": "m_eActorNearbyRequirements" }]
+		},
+		{
+			"SubEntityOperation": [
+				"b44a356315b341eb",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"20ab0f0e926878ee",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"20ab0f0e926878ee",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fCooldownForThis",
+						"value": 15.0
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"463fef8fdf2a48b4",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"463fef8fdf2a48b4",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fCooldownForThis",
+						"value": 15.0
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"34c170b2eec33a51",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"34c170b2eec33a51",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fCooldownForThis",
+						"value": 15.0
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"a1277ea9cb7c2ca4",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"a1277ea9cb7c2ca4",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fCooldownForThis",
+						"value": 15.0
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": ["a88230b8b0cc8f50", { "RemovePropertyByName": "m_eActorNearbyRequirements" }]
 		},
 		{
 			"SubEntityOperation": [
@@ -25,6 +155,9 @@
 			]
 		},
 		{
+			"SubEntityOperation": ["ba732bb94e6b30c2", { "RemovePropertyByName": "m_eActorNearbyRequirements" }]
+		},
+		{
 			"SubEntityOperation": [
 				"ba732bb94e6b30c2",
 				{
@@ -34,6 +167,9 @@
 					}
 				}
 			]
+		},
+		{
+			"SubEntityOperation": ["8e1cd11e2bfd1650", { "RemovePropertyByName": "m_eActorNearbyRequirements" }]
 		},
 		{
 			"SubEntityOperation": [
@@ -47,6 +183,9 @@
 			]
 		},
 		{
+			"SubEntityOperation": ["e67f58a8b67a7b99", { "RemovePropertyByName": "m_eActorNearbyRequirements" }]
+		},
+		{
 			"SubEntityOperation": [
 				"e67f58a8b67a7b99",
 				{
@@ -54,6 +193,69 @@
 						"property_name": "m_ePriority",
 						"value": "eCIP_High"
 					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"4af61e722635776d",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"4af61e722635776d",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fCooldownForThis",
+						"value": 15.0
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"d1ad003297182194",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"6a4222e10e475801",
+				{
+					"PatchArrayPropertyValue": [
+						"m_aHandlers",
+						[
+							{
+								"AddItemAfter": ["63c844e4f28b38ab", "20ab0f0e926878ee"]
+							},
+							{
+								"AddItemAfter": ["63c844e4f28b38ab", "d45304b0f7b652eb"]
+							},
+							{
+								"AddItemAfter": ["63c844e4f28b38ab", "a1277ea9cb7c2ca4"]
+							},
+							{
+								"AddItemAfter": ["63c844e4f28b38ab", "34c170b2eec33a51"]
+							},
+							{
+								"AddItemAfter": ["63c844e4f28b38ab", "4af61e722635776d"]
+							},
+							{
+								"AddItemAfter": ["63c844e4f28b38ab", "463fef8fdf2a48b4"]
+							}
+						]
+					]
 				}
 			]
 		}

--- a/content/SmallFixes/chunk0/FlavorIdleFix/statemachinecoordinator.entity.patch.json
+++ b/content/SmallFixes/chunk0/FlavorIdleFix/statemachinecoordinator.entity.patch.json
@@ -1,0 +1,62 @@
+{
+	"tempHash": "0001F1364984288D",
+	"tbluHash": "00B35AB8FFF33681",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"6ad56c220d337174",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"a88230b8b0cc8f50",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"ba732bb94e6b30c2",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"8e1cd11e2bfd1650",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"e67f58a8b67a7b99",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_ePriority",
+						"value": "eCIP_High"
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Increases their priority from very low to high. This will make 47 do the specific idle for the disguise more consistently, with a caveat. He will only do it if there is specifically 1 NPC in his immediate vicinity in a small radius. If a second NPC enters his little radius when he's in the idle he'll snap out of it. This is, as far as I can tell, out of our control to change and is likely in the C++ layer that we can't touch. Unless there's a possibility for an SDK mod but I wouldn't know about that.

Closes #594