### PR TITLE
feat: restore female custodians' hair model

### DIFF
--- a/content/SmallFixes/chunk1/SgailCustodianHairFix/outfit_magpie_worker_custodian_f_actor_v0.entity.patch.json
+++ b/content/SmallFixes/chunk1/SgailCustodianHairFix/outfit_magpie_worker_custodian_f_actor_v0.entity.patch.json
@@ -1,0 +1,21 @@
+{
+	"tempHash": "00775CC5F09F80E1",
+	"tbluHash": "001419EDA9617608",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"2ec0f6f4995c13d8",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pMeshResource",
+						"value": {
+							"resource": "[assembly:/_pro/characters/assets/_sourcefiles/fem_reg/geometry/fem_reg_hair_long.wl2?/hair_l_ponytail_loose_braid_cut_hat.weightedprim](bodypart).pc_weightedprim",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}

--- a/content/SmallFixes/chunk1/SgailCustodianHairFix/outfit_magpie_worker_custodian_f_actor_v1.entity.patch.json
+++ b/content/SmallFixes/chunk1/SgailCustodianHairFix/outfit_magpie_worker_custodian_f_actor_v1.entity.patch.json
@@ -1,0 +1,21 @@
+{
+	"tempHash": "008CDE0F280CFD1B",
+	"tbluHash": "008DCD0A1424DF04",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"6fa68909078ca027",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pMeshResource",
+						"value": {
+							"resource": "[assembly:/_pro/characters/assets/_sourcefiles/fem_reg/geometry/fem_reg_hair_long.wl2?/hair_l_ponytail_loose_braid_cut_hat.weightedprim](bodypart).pc_weightedprim",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}

--- a/content/SmallFixes/chunk1/SgailCustodianHairFix/outfit_magpie_worker_custodian_f_actor_v2.entity.patch.json
+++ b/content/SmallFixes/chunk1/SgailCustodianHairFix/outfit_magpie_worker_custodian_f_actor_v2.entity.patch.json
@@ -1,0 +1,21 @@
+{
+	"tempHash": "0051959B9A7C03B1",
+	"tbluHash": "006F5708A6C2FBF4",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"18286086da3aeee4",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pMeshResource",
+						"value": {
+							"resource": "[assembly:/_pro/characters/assets/_sourcefiles/fem_reg/geometry/fem_reg_hair_long.wl2?/hair_l_ponytail_loose_braid_cut_hat.weightedprim](bodypart).pc_weightedprim",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}

--- a/content/SmallFixes/chunk1/SgailCustodianHairFix/outfit_magpie_worker_custodian_f_actor_v3.entity.patch.json
+++ b/content/SmallFixes/chunk1/SgailCustodianHairFix/outfit_magpie_worker_custodian_f_actor_v3.entity.patch.json
@@ -1,0 +1,21 @@
+{
+	"tempHash": "00DA843E43F07CBD",
+	"tbluHash": "0096D249659F9E1C",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"a333ac839bb2fe1f",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pMeshResource",
+						"value": {
+							"resource": "[assembly:/_pro/characters/assets/_sourcefiles/fem_reg/geometry/fem_reg_hair_long.wl2?/hair_l_ponytail_loose_braid_cut_hat.weightedprim](bodypart).pc_weightedprim",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Fixes [#601](https://github.com/glacier-modding/H3-Unofficial-Community-Patch/issues/601).

This fixes an outdated file name assignment for female custodians in The Ark Society, which caused them to appear bald despite having an existing hair model.

Credit to @Luiluix for helping me figure out the issue!