### PR TITLE
feat: fix fusebox cover not closing when turned on

### DIFF
--- a/content/SmallFixes/chunk0/FuseboxCoverFix/setpiece_distraction_power_fusebox_inwall.entity.patch.json
+++ b/content/SmallFixes/chunk0/FuseboxCoverFix/setpiece_distraction_power_fusebox_inwall.entity.patch.json
@@ -1,0 +1,30 @@
+{
+	"tempHash": "0072829C6871087C",
+	"tbluHash": "00BB4B2514C73EE6",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"d61eb0bb7e1b3fa1",
+				{
+					"RemoveAllEventConnectionsForTrigger": [
+						"PollFalse",
+						"LidOpen"
+					]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"d61eb0bb7e1b3fa1",
+				{
+					"AddEventConnection": [
+						"PollFalse",
+						"LidClose",
+						"bff15823092bce83"
+					]
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Fixes #564 by making the interaction close the lid instead of opening it (might want to check if it works in VR as "VRHelper_VR_Enabled_Check" was changed but it should be fine)