### PR TITLE
feat: fix Rico don't move in contract mode if you choose the default spawn, by using a transmitter event

### DIFF
--- a/content/SmallFixes/chunk16/RicodontmoveContractfix/scenario_hippo.entity.patch.json
+++ b/content/SmallFixes/chunk16/RicodontmoveContractfix/scenario_hippo.entity.patch.json
@@ -1,0 +1,41 @@
+{
+	"tempHash": "00887DDFD8656D90",
+	"tbluHash": "00FA83E7FF633C2E",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"2dd7e1a2c509b77d",
+				{
+					"AddEventConnection": [
+						"OnPlay",
+						"TransmitEvent",
+						"cafee1b79a94a629"
+					]
+				}
+			]
+		},
+		{
+			"AddEntity": [
+				"cafee1b79a94a629",
+				{
+					"parent": "9c7272adeda746a0",
+					"name": "Stop Rico from waiting for intro",
+					"factory": "[modules:/zeventtransmitterentity_void.class].pc_entitytype",
+					"blueprint": "[modules:/zeventtransmitterentity_void.class].pc_entityblueprint",
+					"properties": {
+						"m_Receivers": {
+							"type": "TArray<SEntityTemplateReference>",
+							"value": [
+								"dd3623f7ec40e51f",
+								"5af8fda5203583ba",
+								"851b4e2a3e3fe727"
+							],
+							"postInit": true
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Before
<img width="2560" height="1440" alt="Capture d’écran (182)" src="https://github.com/user-attachments/assets/161b09d7-84a5-478e-95fc-af1f701542c9" />

After with the fix
<img width="2560" height="1440" alt="Hitman 3 Screenshot 2026 08 19 - 10 59 35 53" src="https://github.com/user-attachments/assets/1abc31f8-2a16-40de-81ef-8fef2932de75" />
